### PR TITLE
Handle File with Changes bulk approvals in Antigravity

### DIFF
--- a/main_scripts/auto-accept.js
+++ b/main_scripts/auto-accept.js
@@ -139,6 +139,58 @@
             }
         };
 
+        const getDirectActionText = (el) => {
+            if (!el || !el.childNodes) return '';
+            let text = '';
+            for (const node of Array.from(el.childNodes)) {
+                if (node && node.nodeType === 3) {
+                    text += node.textContent || '';
+                }
+            }
+            return String(text).toLowerCase().replace(/\s+/g, ' ').trim();
+        };
+
+        const isClickableTextActionNode = (el) => {
+            if (!el) return false;
+
+            const tag = String(el.tagName || '').toLowerCase();
+            if (tag === 'button' || tag === 'a') return true;
+
+            const role = String(el.getAttribute && el.getAttribute('role') || '').toLowerCase();
+            if (role === 'button') return true;
+
+            if (typeof el.onclick === 'function') return true;
+            if (el.hasAttribute && el.hasAttribute('tabindex')) return true;
+
+            try {
+                const style = window.getComputedStyle(el);
+                if (String(style.cursor || '').toLowerCase() === 'pointer') {
+                    return true;
+                }
+            } catch (e) { }
+
+            const cls = String(el.className || '').toLowerCase();
+            return cls.includes('button') || cls.includes('action');
+        };
+
+        const isElementInViewport = (el, margin = 12) => {
+            if (!el || typeof el.getBoundingClientRect !== 'function') return false;
+            try {
+                const rect = el.getBoundingClientRect();
+                if (rect.width <= 0 || rect.height <= 0) return false;
+                if (rect.bottom < margin || rect.right < margin) return false;
+                if (rect.top > (window.innerHeight - margin)) return false;
+                if (rect.left > (window.innerWidth - margin)) return false;
+                return true;
+            } catch (e) {
+                return false;
+            }
+        };
+
+        const getAgentPanel = () => {
+            return queryAll('.antigravity-agent-side-panel').find(el => isElementInViewport(el, 0)) || null;
+        };
+
         const hasStepInputMarkers = () => {
             const markers = [
                 'step requires input',
@@ -369,6 +421,51 @@
         };
 
         const ACTION_NODE_SELECTOR = 'button, [role="button"], a[role="button"]';
+        const isBulkAcceptAction = (txt) => /^(file\s+with\s+changes\s+)?(accept|apply|keep)\s+all\b/i.test(String(txt || '').replace(/\s+/g, ' ').trim());
+        const getBulkActionNodes = (root) => {
+            const baseRoot = root || document;
+            const results = [];
+            const seen = new Set();
+            const add = (node) => {
+                if (!node || seen.has(node)) return;
+                seen.add(node);
+                results.push(node);
+            };
+
+            try {
+                for (const queryRoot of getQueryRoots(baseRoot)) {
+                    getInteractiveNodes(queryRoot).forEach(add);
+
+                    const textNodes = Array.from(queryRoot.querySelectorAll('span, div'));
+                    for (const el of textNodes) {
+                        if (!isClickableTextActionNode(el)) continue;
+
+                        const directText = getDirectActionText(el);
+                        if (!directText) continue;
+                        if (!isBulkAcceptAction(directText) && !/\breject\s+all\b/i.test(directText)) continue;
+
+                        add(el);
+                    }
+                }
+            } catch (e) { }
+
+            return results;
+        };
+        const isFileWithChangesContext = (node) => {
+            let current = node;
+            let depth = 0;
+            while (current && depth < 8) {
+                const text = String(current.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+                const hasFileChangesMarker = /\b(?:\d+\s+)?file(?:s)?\s+with\s+changes\b/i.test(text);
+                const hasBulkChoices = /\breject\s+all\b/i.test(text) && /\baccept\s+all\b/i.test(text);
+                if (hasFileChangesMarker && hasBulkChoices) {
+                    return true;
+                }
+                current = current.parentElement;
+                depth++;
+            }
+            return false;
+        };
         const PERMISSION_PROMPT_MARKERS = [
             'opening url in browser',
             'needs permission to act on',
@@ -505,6 +602,49 @@
 
         for (const container of promptContainers) {
             if (tryApprovePermissionInContainer(container, 'prompt-scope')) {
+                return clickedCount;
+            }
+        }
+
+        // Handle Antigravity bulk approval cards rendered in the side panel.
+        const bulkActionButtons = [];
+        const seenBulkActionButtons = new Set();
+        for (const container of promptContainers) {
+            try {
+                const scopedBulkButtons = getBulkActionNodes(container);
+                for (const btn of scopedBulkButtons) {
+                    if (!seenBulkActionButtons.has(btn)) {
+                        seenBulkActionButtons.add(btn);
+                        bulkActionButtons.push(btn);
+                    }
+                }
+            } catch (e) { }
+        }
+
+        const fileWithChangesAccept = getBulkActionNodes(getAgentPanel() || document).find(btn => {
+            const text = getDirectActionText(btn) || getActionText(btn);
+            if (!/\baccept\s+all\b/i.test(text)) return false;
+            if (!isElementInViewport(btn, 16)) return false;
+            return isFileWithChangesContext(btn);
+        });
+
+        if (fileWithChangesAccept && clickElement(fileWithChangesAccept, 'bulk-accept')) {
+            log(`File with changes approved automatically: "${getActionText(fileWithChangesAccept)}"`);
+            return clickedCount;
+        }
+
+        for (const btn of bulkActionButtons) {
+            const text = getDirectActionText(btn) || getActionText(btn);
+            if (!isBulkAcceptAction(text)) continue;
+            if (!isElementInViewport(btn, 16)) continue;
+
+            const container = btn.closest('[role="dialog"], .notification-toast, .notification-list-item, .monaco-dialog-box, .monaco-dialog-modal-block, .chat-tool-call, .chat-tool-response, [class*="tool-call"], [data-testid*="tool-call"], .antigravity-agent-side-panel') || btn.parentElement;
+            const containerText = getActionText(container || btn);
+            const neighbors = container ? getBulkActionNodes(container) : [];
+            if (isPermissionPromptContainer(containerText, neighbors)) continue;
+
+            if (clickElement(btn, 'bulk-accept')) {
+                log(`Bulk action approved automatically: "${text}"`);
                 return clickedCount;
             }
         }

--- a/main_scripts/auto-accept.test.js
+++ b/main_scripts/auto-accept.test.js
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptSource = fs.readFileSync(path.join(__dirname, 'auto-accept.js'), 'utf8');
+
+function loadScript() {
+    window.eval(scriptSource);
+}
+
+function buildBulkPrompt({ offscreen = false } = {}) {
+    const card = document.createElement('div');
+    const title = document.createElement('div');
+    title.textContent = '1 File with Changes';
+
+    const reject = document.createElement('span');
+    reject.className = 'action';
+    reject.tabIndex = 0;
+    reject.textContent = 'Reject All';
+
+    const accept = document.createElement('span');
+    accept.className = 'action';
+    accept.tabIndex = 0;
+    accept.textContent = 'Accept All';
+    if (offscreen) {
+        accept.dataset.offscreen = '1';
+        reject.dataset.offscreen = '1';
+        title.dataset.offscreen = '1';
+        card.dataset.offscreen = '1';
+    }
+
+    card.append(title, reject, accept);
+    return { card, accept };
+}
+
+describe('auto-accept bulk approval handling', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+        Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+
+        Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            value() {
+                if (this.dataset && this.dataset.offscreen === '1') {
+                    return { top: -200, left: 10, bottom: -120, right: 180, width: 170, height: 80 };
+                }
+                return { top: 40, left: 10, bottom: 120, right: 180, width: 170, height: 80 };
+            }
+        });
+
+        loadScript();
+    });
+
+    afterEach(() => {
+        window.__autoAcceptStop?.();
+        delete window.__autoAcceptFreeState;
+        delete window.__autoAcceptGetStats;
+        delete window.__autoAcceptStart;
+        delete window.__autoAcceptStop;
+        delete window.__autoAcceptUpdateBannedCommands;
+        vi.restoreAllMocks();
+    });
+
+    it('clicks the visible File with Changes Accept All action and ignores offscreen stale actions', async () => {
+        const panel = document.createElement('div');
+        panel.className = 'antigravity-agent-side-panel';
+
+        const stale = buildBulkPrompt({ offscreen: true });
+        const current = buildBulkPrompt();
+
+        let staleClicks = 0;
+        let currentClicks = 0;
+        stale.accept.addEventListener('click', () => { staleClicks += 1; });
+        current.accept.addEventListener('click', () => { currentClicks += 1; });
+
+        panel.append(stale.card, current.card);
+        document.body.append(panel);
+
+        window.__autoAcceptStart({ ide: 'antigravity', bannedCommands: [] });
+        await new Promise(resolve => setTimeout(resolve, 350));
+
+        expect(staleClicks).toBe(0);
+        expect(currentClicks).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary
- detect prompt-scoped bulk approval actions rendered as clickable text nodes in the Antigravity side panel
- add a dedicated `File with Changes -> Accept All` path so bulk file-change prompts are handled reliably
- ignore offscreen stale bulk actions so older prompts above the fold are not clicked accidentally
- add a jsdom regression test covering the visible-vs-offscreen file-change bulk prompt case

## Why
Some Antigravity bulk approval cards are rendered in the side panel in a way that is not always exposed as a normal button. That leaves `Accept All` unhandled even though the prompt is visible and actionable.

## Testing
- `node --check main_scripts/auto-accept.js`
- `npm test`